### PR TITLE
Cls revisited

### DIFF
--- a/Java/src/main/java/com/nuix/javaenginesimple/EngineWrapper.java
+++ b/Java/src/main/java/com/nuix/javaenginesimple/EngineWrapper.java
@@ -241,7 +241,7 @@ public class EngineWrapper {
 	 * Exceptions are caught locally, logged and then rethrown.
 	 */
 	public void withCloudLicense(final String userName, final String password, Consumer<Utilities> consumer) throws Exception{
-		System.getProperties().put("nuix.registry.servers", "http://https://licence-api.nuix.com");
+		System.getProperties().put("nuix.registry.servers", "https://licence-api.nuix.com");
 		
 		// Make sure we have a valid path to Nuix distributable
 		if(nuixBaseDirectory == null){

--- a/Java/src/main/java/com/nuix/javaenginesimple/EngineWrapper.java
+++ b/Java/src/main/java/com/nuix/javaenginesimple/EngineWrapper.java
@@ -231,6 +231,99 @@ public class EngineWrapper {
 	}
 	
 	/***
+	 * Attempts to obtain a cloud server based license.  If and when a cloud server based license is obtained, a Utilities object will be
+	 * provided to consumer, which may then make use of the Nuix API to do work.  Once the consumer has returned this method will
+	 * cleanup the Engine and GlobalContainer instances it created.
+	 * @param userName Username to provide cloud license server
+	 * @param password Password to provide cloud license server
+	 * @param consumer Consumer which will make use of Utilities object once a license has been obtained.
+	 * @throws Exception May throw exceptions due to: error creating GlobalContainer, error creating Engine instance or error obtaining license.
+	 * Exceptions are caught locally, logged and then rethrown.
+	 */
+	public void withCloudLicense(final String userName, final String password, Consumer<Utilities> consumer) throws Exception{
+		System.getProperties().put("nuix.registry.servers", "http://https://licence-api.nuix.com");
+		
+		// Make sure we have a valid path to Nuix distributable
+		if(nuixBaseDirectory == null){
+			throw new Exception(String.format("Value provided for nuixBaseDirectory is invalid, value provided is: %s",nuixBaseDirectory));
+		}
+		
+		// Warn if we don't have a certificate trust callback.  Technically this license acquisition could succeed without
+		// one, but there is also a good chance it will fail.  If it fails, its good to have something in the log suggesting what
+		// the user could do to resolve the issue.
+		if(certificateTrustCallback == null) {
+			String message = "No CertificateTrustCallback was provided.  Please either call EngineWrapper.trustAllCertificates() or "+
+					"EnginerWrapper.setCertificateTrustCallback(CertificateTrustCallback certificateTrustCallback) before attempting to "+
+					"obtain a license from a license server.";
+			logger.warn(message);
+		}
+		
+		logger.info("Creating GlobalContainer...");
+		try {
+			// We start by getting our hands on a GlobalContainer instance.  There can only
+			// be one of these per Java process.
+			if(container == null){
+				container = nuix.engine.GlobalContainerFactory.newContainer();	
+			}
+			
+			logger.info("Initializing engine....");
+			try {
+				// Next we build an Engine instance from the GlobalContainer
+				configureAndBuildEngine();
+				
+				logger.info("Specifying credentials to use with cloud license server...");
+				engine.whenAskedForCredentials(new CredentialsCallback() {
+					Logger logger = Logger.getLogger("CredentialCallback");
+					public void execute(CredentialsCallbackInfo info) {
+						logger.info(String.format("Providing credentials for %s to cloud license server %s...", userName,info.getAddress().getHostName()));
+						info.setUsername(userName);
+						info.setPassword(password);
+					}
+				});
+				
+				if(certificateTrustCallback != null) {
+					engine.whenAskedForCertificateTrust(certificateTrustCallback);
+				}
+				
+				logger.info("Attempting to obtain a license...");
+				try {
+					Map<String,Object> licenseOptions = new HashMap<String,Object>();
+					licenseOptions.put("sources","cloud-server");
+					
+					boolean licenseObtained = obtainLicense(licenseOptions);
+					if(licenseObtained){
+						Utilities utilities = engine.getUtilities();
+						ThirdPartyDependencyChecker.logAllDependencyInfo(utilities);
+						logger.info("License was obtained, providing Utilities object to consumer...");
+						consumer.accept(utilities);
+					} else {
+						logger.warn("License was not obtained");
+					}
+				} catch (Exception licenseException) {
+					logger.error("Error obtaining license",licenseException);
+					throw licenseException;
+				}
+			} catch (Exception engineException) {
+				logger.error("Error while creating Engine instance",engineException);
+				throw engineException;
+			} finally {
+				if(engine != null){
+					logger.info("Closing Engine instance...");
+					engine.close();
+				}
+			}
+		} catch (Exception globalContainerException) {
+			logger.error("Error while creating GlobalContainer",globalContainerException);
+			throw globalContainerException;
+		} finally {
+			if(container != null){
+				logger.info("Closing GlobalContainer...");
+				container.close();
+			}
+		}
+	}
+	
+	/***
 	 * Obtains the first found license which meets the specified license options.
 	 * @param licenseOptions The options passed to Licensor while finding licenses.
 	 * @return True if a license was obtained, false otherwise.

--- a/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
+++ b/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
@@ -20,6 +20,10 @@ public class EntryPoint {
 	private final static Logger logger = Logger.getLogger("EntryPoint");
 
 	public static void main(String[] args) throws Exception {
+		
+		// ==================================
+		// * Configure some logging details *
+		// ==================================
 		// Specify a custom location for our log files
 		String logDirectory = String.format("C:\\NuixEngineLogs\\%s",DateTime.now().toString("YYYYMMDD_HHmmss"));
 		System.getProperties().put("nuix.logdir", logDirectory);
@@ -30,16 +34,48 @@ public class EntryPoint {
 		InputStream log4jSettingsStream = EntryPoint.class.getResourceAsStream("/log4j.properties");
 		props.load(log4jSettingsStream);
 		PropertyConfigurator.configure(props);
+		
+		
+		// =========================================================================================
+		// * Create instance of EngineWrapper which we will delegate much of the initialization to *
+		// =========================================================================================
 				
 		// Create an instance of engine wrapper, which will do the work of getting the Nuix bits initialized.
 		// Engine wrapper will need to know what directory you engine release resides.
 		EngineWrapper wrapper = new EngineWrapper("D:\\engine-releases\\8.4.2.466");
+		
+		
+		// =========================================================================================================
+		// * Create LicenseFilter instance which will instruct EngineWrapper on how to choose an available license *
+		// =========================================================================================================
 		
 		// LicenseFilter is used by EngineWrapper to select which license to obtain
 		// from available licenses.
 		LicenseFilter licenseFilter = wrapper.getLicenseFilter();
 		licenseFilter.setMinWorkers(4);
 		licenseFilter.addRequiredFeature("CASE_CREATION");
+		
+		
+		// =================================================================================
+		// * Example of getting license authentication details from command line arguments *
+		// =================================================================================
+		
+		// Provided via: -DLicense.UserName=username
+		String licenseUserName = System.getProperty("License.UserName");
+		// Provided via: -DLicense.Password=password
+		String licensePassword = System.getProperty("License.Password");
+		
+		if(licenseUserName != null && !licenseUserName.trim().isEmpty()) {
+			logger.info(String.format("License username was provided via argument -DLicense.UserName: %s",licenseUserName));
+		}
+		
+		if(licensePassword != null && !licensePassword.trim().isEmpty()) {
+			logger.info("License password was provided via argument -DLicense.Password");
+		}
+		
+		// =========================================================================================================
+		// * Use EnginerWrapper to obtain a licensed Utilities instance (thus allowing you to use Nuix engine API) *
+		// =========================================================================================================
 		
 		try {
 			// Attempt to initialize Nuix with a dongle based license
@@ -48,14 +84,13 @@ public class EntryPoint {
 //					// Here's where we would begin to make use of the Nuix API for
 //					// the more interesting things like opening a case, searching ,tagging, etc
 //					logger.info("Looks like it worked! Now time to do something great.");
-//					
 //					//TODO: Use Nuix to do stuff
 //				}
 //			});
 			
 			// Attempt to initialize Nuix with a server based license
 //			wrapper.trustAllCertificates();
-//			wrapper.withServerLicense("127.0.0.1", "nuix", "nuixpassword", new Consumer<Utilities>(){
+//			wrapper.withServerLicense("127.0.0.1", licenseUserName, licensePassword, new Consumer<Utilities>(){
 //				public void accept(Utilities utilities) {
 //					// Here's where we would begin to make use of the Nuix API for
 //					// the more interesting things like opening a case, searching ,tagging, etc
@@ -64,8 +99,9 @@ public class EntryPoint {
 //				}
 //			});
 			
+			// Attempt to initialize Nuix with a cloud based license
 			wrapper.trustAllCertificates();
-			wrapper.withCloudLicense("nuixuser", "nuixpassword", new Consumer<Utilities>() {
+			wrapper.withCloudLicense(licenseUserName, licensePassword, new Consumer<Utilities>() {
 				public void accept(Utilities utilities) {
 					// Here's where we would begin to make use of the Nuix API for
 					// the more interesting things like opening a case, searching ,tagging, etc

--- a/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
+++ b/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
@@ -33,7 +33,7 @@ public class EntryPoint {
 				
 		// Create an instance of engine wrapper, which will do the work of getting the Nuix bits initialized.
 		// Engine wrapper will need to know what directory you engine release resides.
-		EngineWrapper wrapper = new EngineWrapper("D:\\engine-releases\\8.0.3.121");
+		EngineWrapper wrapper = new EngineWrapper("D:\\engine-releases\\8.4.2.466");
 		
 		// LicenseFilter is used by EngineWrapper to select which license to obtain
 		// from available licenses.

--- a/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
+++ b/Java/src/main/java/com/nuix/javaenginesimple/EntryPoint.java
@@ -54,8 +54,18 @@ public class EntryPoint {
 //			});
 			
 			// Attempt to initialize Nuix with a server based license
+//			wrapper.trustAllCertificates();
+//			wrapper.withServerLicense("127.0.0.1", "nuix", "nuixpassword", new Consumer<Utilities>(){
+//				public void accept(Utilities utilities) {
+//					// Here's where we would begin to make use of the Nuix API for
+//					// the more interesting things like opening a case, searching ,tagging, etc
+//					logger.info("Looks like it worked! Now time to do something great.");
+//					//TODO: Use Nuix to do stuff
+//				}
+//			});
+			
 			wrapper.trustAllCertificates();
-			wrapper.withServerLicense("127.0.0.1", "nuix", "nuixpassword", new Consumer<Utilities>(){
+			wrapper.withCloudLicense("nuixuser", "nuixpassword", new Consumer<Utilities>() {
 				public void accept(Utilities utilities) {
 					// Here's where we would begin to make use of the Nuix API for
 					// the more interesting things like opening a case, searching ,tagging, etc


### PR DESCRIPTION
Implemented EngineWrapper.withCloudLicense as an example of obtaining a license from the cloud license server