### PR TITLE
Example/main entry point

### DIFF
--- a/IntelliJ/build.gradle.kts
+++ b/IntelliJ/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.nuix.innovation"
-version = "Nuix9.10-v1.1.5"
+version = "Nuix9.10-v1.1.6"
 
 val sourceCompatibility = 11
 val targetCompatibility = 11

--- a/IntelliJ/src/main/java/com/nuix/innovation/enginewrapper/App.java
+++ b/IntelliJ/src/main/java/com/nuix/innovation/enginewrapper/App.java
@@ -1,0 +1,79 @@
+package com.nuix.innovation.enginewrapper;
+
+import nuix.Utilities;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+import java.util.Map;
+
+public class App {
+    private static final Logger log = LoggerFactory.getLogger(App.class);
+    private static boolean logEnvDetails = true;
+
+    public static void main(String[] args) {
+        logEnvDetails();
+
+        try (NuixEngine nuixEngine = constructNuixEngine()) {
+            Utilities utilities = nuixEngine.getUtilities();
+
+            // This is where the magic happens.  In this scope, Nuix should be licensed.
+            // To run a test in the IDE, I recommend invoking from AppTest in the project tests.
+
+            log.info("Nuix Engine Version: {}", nuixEngine.getNuixVersionString());
+
+        } catch (Exception exc) {
+            log.error("Uncaught exception, exiting", exc);
+        }
+    }
+
+    private static void logEnvDetails() {
+        if (logEnvDetails) {
+            System.out.println("JVM Arguments:");
+            RuntimeMXBean bean = ManagementFactory.getRuntimeMXBean();
+            List<String> jvmArgs = bean.getInputArguments();
+            for (String arg : jvmArgs) {
+                System.out.println(arg);
+            }
+
+            System.out.println("Environment Variables:");
+            for (Map.Entry<String, String> entry : System.getenv().entrySet()) {
+                System.out.println(String.format("%s => %s", entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+
+    /***
+     * Tests will generally call this method to construct the instance of NuixEngine they will use to perform
+     * their given test.  This allows you to customize it to your environment without having to alter all the tests.
+     * @return A NuixEngine instance ready to use
+     */
+    public static NuixEngine constructNuixEngine(String... additionalRequiredFeatures) throws IOException {
+        List<String> features = List.of("CASE_CREATION");
+        if (additionalRequiredFeatures != null && additionalRequiredFeatures.length > 0) {
+            features.addAll(List.of(additionalRequiredFeatures));
+        }
+
+        NuixLicenseResolver cloud = NuixLicenseResolver.fromCloud()
+                .withLicenseCredentialsResolvedFromEnvVars()
+                .withMinWorkerCount(4)
+                .withRequiredFeatures(features);
+
+        NuixLicenseResolver dongle = NuixLicenseResolver.fromDongle()
+                .withRequiredFeatures(features);
+
+        NuixLicenseResolver nms = NuixLicenseResolver.fromServer("<NMS HOST OR IP>")
+                .withMinWorkerCount(4)
+                .withRequiredFeatures(features)
+                .withRequiredFeatures(features);
+
+        return NuixEngine.usingFirstAvailableLicense(cloud, nms, dongle)
+                .setEngineDistributionDirectoryFromEnvVar()
+                .setLogDirectory(new File("C:/NuixEngineLogs/", DateTime.now().toString("YYYY-MM-dd_HH-mm-ss")).getCanonicalFile());
+    }
+}

--- a/IntelliJ/src/main/java/com/nuix/innovation/enginewrapper/NuixEngine.java
+++ b/IntelliJ/src/main/java/com/nuix/innovation/enginewrapper/NuixEngine.java
@@ -458,8 +458,15 @@ public class NuixEngine implements AutoCloseable {
             }
         }
 
-        // Make sure PATH points to expected bin and bin/x86 subdirectories of our engine distribution
-        String envPath = System.getenv("PATH");
+        // Make sure PATH points to expected bin and bin/x86 subdirectories of our engine distribution.  Since it seems
+        // that case of the key "Path" vs "PATH" can matter, we will search for it in a case insensitive manner.
+        String envPath = null;
+        for(Map.Entry<String,String> envEntry : System.getenv().entrySet()) {
+            if(envEntry.getKey().trim().equalsIgnoreCase("PATH")) {
+                envPath = envEntry.getValue();
+                break;
+            }
+        }
 
         if (envPath == null || envPath.isBlank()) {
             if (!ignoreIssues) {

--- a/IntelliJ/src/test/java/AppTest.java
+++ b/IntelliJ/src/test/java/AppTest.java
@@ -1,0 +1,9 @@
+import com.nuix.innovation.enginewrapper.App;
+import org.junit.jupiter.api.Test;
+
+public class AppTest {
+    @Test
+    public void Test() throws Exception {
+        App.main(new String[]{});
+    }
+}

--- a/IntelliJ/src/test/java/CommonTestFunctionality.java
+++ b/IntelliJ/src/test/java/CommonTestFunctionality.java
@@ -1,6 +1,7 @@
 import com.nuix.innovation.enginewrapper.NuixEngine;
 import com.nuix.innovation.enginewrapper.NuixLicenseResolver;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
@@ -10,7 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.util.*;
+import java.util.List;
 
 public class CommonTestFunctionality {
     // Used in some tests, this is a simple class to hold
@@ -75,7 +76,7 @@ public class CommonTestFunctionality {
      * @return A NuixEngine instance ready to use
      */
     public NuixEngine constructNuixEngine() throws IOException {
-        return constructNuixEngine((String[])null);
+        return constructNuixEngine((String[]) null);
     }
 
     /***
@@ -85,7 +86,7 @@ public class CommonTestFunctionality {
      */
     public NuixEngine constructNuixEngine(String... additionalRequiredFeatures) throws IOException {
         List<String> features = List.of("CASE_CREATION");
-        if(additionalRequiredFeatures != null && additionalRequiredFeatures.length > 0) {
+        if (additionalRequiredFeatures != null && additionalRequiredFeatures.length > 0) {
             features.addAll(List.of(additionalRequiredFeatures));
         }
 
@@ -99,6 +100,6 @@ public class CommonTestFunctionality {
 
         return NuixEngine.usingFirstAvailableLicense(caseCreationCloud, caseCreationDongle)
                 .setEngineDistributionDirectoryFromEnvVar()
-                .setLogDirectory(new File(testOutputDirectory, "Logs_"+System.currentTimeMillis()).getCanonicalFile());
+                .setLogDirectory(new File(testOutputDirectory, DateTime.now().toString("YYYY-MM-dd_HH-mm-ss")).getCanonicalFile());
     }
 }


### PR DESCRIPTION
- Demonstrate a main method entry point and a way to test it.
- Tweak to `PATH` pre-check that should be case insensitive such that environment variable can be `Path` or `PATH`.